### PR TITLE
Add setup submodule script

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,13 @@ These submodules come from their respective GitHub repositories and are not incl
 
 ## Fetching submodules
 
-After cloning this repository run the following command to download all required code:
-
+After cloning this repository run the setup script to download all required code:
 
 ```bash
-git submodule update --init --recursive
+./setup.sh
 ```
+
+The script simply executes `git submodule update --init --recursive` to populate each directory.
 
 
 ## Project structure

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+
+git submodule update --init --recursive


### PR DESCRIPTION
## Summary
- add a `setup.sh` helper script for initializing submodules
- document using `./setup.sh` in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68799b8b67648324b0929482e3268386