### PR TITLE
Enable node dragging on interactive map

### DIFF
--- a/docs/interactive-map.html
+++ b/docs/interactive-map.html
@@ -67,6 +67,9 @@ function render(nodes, links) {
       .attr('text-anchor', 'middle')
       .text(d => d.id);
 
+  // Allow repositioning of nodes
+  node.call(drag(simulation));
+
   simulation.on('tick', () => {
     link
         .attr('x1', d => d.source.x)


### PR DESCRIPTION
## Summary
- let users drag nodes in `docs/interactive-map.html`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68799becd0e08324b2a9ebf855cebd5a