### PR TITLE
Fix submodule host in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "exosystem/exosys-folg"]
 	path = exosystem/exosys-folg
-	url = git@github-phi:artphytau/exosys-folg.git
+	url = git@github.com:artphytau/exosys-folg.git
 [submodule "afrhone/template"]
 	path = afrhone/template
 	url = git@github.com:spectra-gallery/aligonde-ideo.git


### PR DESCRIPTION
## Summary
- fix `github-phi` host in `.gitmodules`

## Testing
- `git ls-remote git@github-phi:artphytau/exosys-folg.git HEAD` *(fails: `Could not resolve hostname github-phi`)*

------
https://chatgpt.com/codex/tasks/task_e_68799bf8f52883249ec3da88b945dd2a