### PR TITLE
Fix docs and enable map dragging

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "exosystem/exosys-folg"]
-	path = exosystem/exosys-folg
-	url = git@github-phi:artphytau/exosys-folg.git
+        path = exosystem/exosys-folg
+        url = git@github.com:artphytau/exosys-folg.git
 [submodule "afrhone/template"]
 	path = afrhone/template
 	url = git@github.com:spectra-gallery/aligonde-ideo.git

--- a/README.md
+++ b/README.md
@@ -54,11 +54,7 @@ The broader architecture centers around two services:
 - **spectra-playground-server** – backend service used for experimentation and APIs.
 - **spectra-frontend** – web front end communicating with the playground server.
 
-Other submodules provide library code and infrastructure used by these two applications. Javascript is the primary language for the frontend and some server tooling.
-
-This will pull down each external project into its directory so that the entire tree builds correctly.
-
-## Intended architecture
+Other submodules provide library code and infrastructure used by these two applications. Javascript is the primary language for the frontend and some server tooling. This will pull down each external project into its directory so that the entire tree builds correctly.
 
 The Uniphi Lab stack combines several services.  A `spectra-playground-server` provides backend capabilities while a `spectra-frontend` offers a web interface.  Supporting projects such as `spectra-infra` and the social graph repositories provide the foundation.  Together they form the environment visualized in the interactive map.
 

--- a/docs/interactive-map.html
+++ b/docs/interactive-map.html
@@ -67,6 +67,8 @@ function render(nodes, links) {
       .attr('text-anchor', 'middle')
       .text(d => d.id);
 
+  node.call(drag(simulation));
+
   simulation.on('tick', () => {
     link
         .attr('x1', d => d.source.x)


### PR DESCRIPTION
## Summary
- fix typo in exosys-folg submodule url
- combine duplicate README architecture section
- enable drag on interactive map nodes

## Testing
- `git submodule sync`
- `git submodule update --init --recursive` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687934ca438083248b5a110d41603faa